### PR TITLE
Handle null results for data

### DIFF
--- a/src/manager/persister.js
+++ b/src/manager/persister.js
@@ -68,6 +68,9 @@ export default class Persister {
         return this._queryAPI(graphqlify(queryObject));
       })
       .then(data => {
+        if (!data.data) {
+          return [];
+        }
         return data.data.map(str => JSON.parse(str));
       });
   }


### PR DESCRIPTION
The data field can have null as a value. Return an empty
array if this happens.
